### PR TITLE
Fix final train/validation size

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -33,7 +33,7 @@ class Data:
 
         self.X_train, self.X_val, self.y_train, self.y_val = train_test_split(self.X_train,
                                                                               self.y_train,
-                                                                              test_size=validation_size / train_size,
+                                                                              test_size=validation_size / (1 - test_size),
                                                                               random_state=random_seed)
 
         assert (self.X_train.shape[0] + self.X_val.shape[0] + self.X_test.shape[0]) == X.shape[0]


### PR DESCRIPTION
With current implementation, final training and validation sizes are 0.533 and 0.266 (respectively) of the original dataset.

With the fix, final training and validation sizes are 0.6 and 0.2 of the original dataset.